### PR TITLE
correction for issue-86 in VectorPackingKPSimple.filterFullDim

### DIFF
--- a/choco/src/main/java/org/btrplace/scheduler/choco/extensions/pack/VectorPackingKPSimpleDecorator.java
+++ b/choco/src/main/java/org/btrplace/scheduler/choco/extensions/pack/VectorPackingKPSimpleDecorator.java
@@ -143,23 +143,26 @@ public class VectorPackingKPSimpleDecorator {
         System.out.println(bin + " is full on dim " + dim);
         for (int i = candidate.get(bin).nextSetBit(0); i >= 0; i = candidate.get(bin).nextSetBit(i + 1)) {
             //assert p.bins[i].contains(bin) : p.bins[i] + " bin=" + bin + " item=" + i;
-            if (/*p.bins[i].contains(bin) && */p.iSizes[dim][i] > 0) {
+            // ISSUE 86: the event 'i removed from bin' can already been in the propagation stack but not yet considered
+            // ie. !p.bins[i].contains(bin) && candidate[bin].contains(i): in this case, do not process it yet
+            if (p.bins[i].contains(bin) && p.iSizes[dim][i] > 0) {
                 boolean b = p.bins[i].removeValue(bin, p.getACause());
                 System.out.println("KP Remove item " + i + " from bin " + bin + ": " + b);
+                candidate.get(bin).clear(i);
+                p.potentialLoad[dim][bin].add(-1*p.iSizes[dim][i]);
+                System.out.println("potentialLoad dim=" + dim + ", bin=" + bin + " -> " + p.potentialLoad[dim][bin].get());
                 if (p.bins[i].isInstantiated()) {
                     System.out.println("\tnow assigned to " + p.bins[i].getValue());
                     p.assignItem(i, p.bins[i].getValue());
                 }
             }
-            candidate.get(bin).clear(i);
         }
-        //candidate.get(bin).clear();
+        if (candidate.get(bin).isEmpty()) {
         //for (int d = 0; d < p.nbDims; d++) {
-        p.potentialLoad[dim][bin].set(p.assignedLoad[dim][bin].get());
-        System.out.println("potentialLoad dim=" + dim + ", bin=" + bin + " -> " + p.assignedLoad[dim][bin].get());
-        assert p.loads[dim][bin].getUB() == p.potentialLoad[dim][bin].get();
+            assert p.potentialLoad[dim][bin].get() == p.assignedLoad[dim][bin].get();
+            assert p.loads[dim][bin].getUB() == p.potentialLoad[dim][bin].get();
         //p.filterLoadSup(dim, bin, p.potentialLoad[dim][bin].get());
-        //}
+        }
     }
 
     /**


### PR DESCRIPTION
This issue is due to an event synchronization problem: we must ensure that a candidate item is still potentially on a bin before removing it. This is not the case if the event "remove item from bin" is on the propagation stack but not yet propagated.