### PR TITLE
Build reports are not always needed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
         <testng.version>7.3.0</testng.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+    	<closeTestReports>true</closeTestReports>
     </properties>
     <licenses>
         <license>
@@ -203,6 +204,7 @@
                     </includes>
                 	<parallel>classes</parallel>
                     <threadCount>5</threadCount>
+                	<disableXmlReport>${closeTestReports}</disableXmlReport>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION

That report generation takes time, slowing down the overall build. Reports are definitely useful, but do you need them every time you run the build. We can conditionally disable generating test reports by setting `<disableXmlReport>true<disableXmlReport>`. If you need to generate reports, just add `-DcloseTestReports=false` to the end of mvn build command.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
