### PR TITLE
Provides misplacedVMs from ReconfigurationProblem.

### DIFF
--- a/choco/src/main/java/org/btrplace/scheduler/choco/DefaultReconfigurationProblem.java
+++ b/choco/src/main/java/org/btrplace/scheduler/choco/DefaultReconfigurationProblem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright  2023 The BtrPlace Authors. All rights reserved.
+ * Copyright  2024 The BtrPlace Authors. All rights reserved.
  * Use of this source code is governed by a LGPL-style
  * license that can be found in the LICENSE.txt file.
  */
@@ -71,6 +71,8 @@ public class DefaultReconfigurationProblem implements ReconfigurationProblem {
 
     private Set<VM> manageable;
 
+    private final Set<VM> misplaced;
+
     private List<VM> vms;
     private TObjectIntHashMap<VM> revVMs;
 
@@ -86,7 +88,6 @@ public class DefaultReconfigurationProblem implements ReconfigurationProblem {
     private final DurationEvaluators durEval;
 
     private List<IntVar> vmsCountOnNodes;
-
 
     private ResolutionPolicy solvingPolicy;
 
@@ -120,7 +121,8 @@ public class DefaultReconfigurationProblem implements ReconfigurationProblem {
                                   Set<VM> running,
                                   Set<VM> sleeping,
                                   Set<VM> killed,
-                                  Set<VM> preRooted) throws SchedulerException {
+                                  Set<VM> preRooted,
+                                  Set<VM> misplaced) throws SchedulerException {
         this.ready = new HashSet<>(ready);
         this.running = new HashSet<>(running);
         this.sleeping = new HashSet<>(sleeping);
@@ -149,6 +151,7 @@ public class DefaultReconfigurationProblem implements ReconfigurationProblem {
         makeNodeTransitions();
         makeVMTransitions();
         manageable = Collections.unmodifiableSet(manageable);
+        this.misplaced = Collections.unmodifiableSet(misplaced);
         coreViews = new HashMap<>();
         for (Class<? extends ChocoView> c : ps.getChocoViews()) {
             try {
@@ -643,6 +646,11 @@ public class DefaultReconfigurationProblem implements ReconfigurationProblem {
     @Override
     public Set<VM> getManageableVMs() {
         return manageable;
+    }
+
+    @Override
+    public Set<VM> getMisplacedVMs() {
+        return this.misplaced;
     }
 
     @Override

--- a/choco/src/main/java/org/btrplace/scheduler/choco/DefaultReconfigurationProblem.java
+++ b/choco/src/main/java/org/btrplace/scheduler/choco/DefaultReconfigurationProblem.java
@@ -112,6 +112,7 @@ public class DefaultReconfigurationProblem implements ReconfigurationProblem {
      * @param sleeping  the VMs that must be in the sleeping state
      * @param killed    the VMs that must be killed
      * @param preRooted the VMs that can be managed by the solver when they are already running and they must keep running
+     * @param misplaced the VMs that are misplaced by views and constraints implementing.
      * @throws org.btrplace.scheduler.SchedulerException if an error occurred
      * @see DefaultReconfigurationProblemBuilder to ease the instantiation process
      */

--- a/choco/src/main/java/org/btrplace/scheduler/choco/DefaultReconfigurationProblemBuilder.java
+++ b/choco/src/main/java/org/btrplace/scheduler/choco/DefaultReconfigurationProblemBuilder.java
@@ -135,7 +135,7 @@ public class DefaultReconfigurationProblemBuilder {
         }
 
         if (misplaced == null) {
-            misplaced = new HashSet<>();
+            misplaced = Collections.emptySet();
         }
         if (ps == null) {
             ps = new DefaultParameters();

--- a/choco/src/main/java/org/btrplace/scheduler/choco/DefaultReconfigurationProblemBuilder.java
+++ b/choco/src/main/java/org/btrplace/scheduler/choco/DefaultReconfigurationProblemBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright  2020 The BtrPlace Authors. All rights reserved.
+ * Copyright  2024 The BtrPlace Authors. All rights reserved.
  * Use of this source code is governed by a LGPL-style
  * license that can be found in the LICENSE.txt file.
  */
@@ -30,7 +30,7 @@ import java.util.Set;
  */
 public class DefaultReconfigurationProblemBuilder {
 
-  private final Model model;
+    private final Model model;
 
     private Set<VM> runs;
     private Set<VM> waits;
@@ -38,6 +38,8 @@ public class DefaultReconfigurationProblemBuilder {
     private Set<VM> sleep;
 
     private Set<VM> manageable;
+
+    private Set<VM> misplaced;
 
     private Parameters ps;
 
@@ -94,6 +96,17 @@ public class DefaultReconfigurationProblemBuilder {
     }
 
     /**
+     * Set the VMs that are considered to be misplaced.
+     *
+     * @param vms the set of VMs
+     * @return the current builder
+     */
+    public DefaultReconfigurationProblemBuilder setMisplacedVMs(Set<VM> vms) {
+        misplaced = vms;
+        return this;
+    }
+
+    /**
      * Build the problem
      *
      * @return the builder problem
@@ -121,10 +134,13 @@ public class DefaultReconfigurationProblemBuilder {
             manageable.addAll(model.getMapping().getReadyVMs());
         }
 
+        if (misplaced == null) {
+            misplaced = new HashSet<>();
+        }
         if (ps == null) {
             ps = new DefaultParameters();
         }
-        return new DefaultReconfigurationProblem(model, ps, waits, runs, sleep, over, manageable);
+        return new DefaultReconfigurationProblem(model, ps, waits, runs, sleep, over, manageable, misplaced);
     }
 
 }

--- a/choco/src/main/java/org/btrplace/scheduler/choco/ReconfigurationProblem.java
+++ b/choco/src/main/java/org/btrplace/scheduler/choco/ReconfigurationProblem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright  2022 The BtrPlace Authors. All rights reserved.
+ * Copyright  2024 The BtrPlace Authors. All rights reserved.
  * Use of this source code is governed by a LGPL-style
  * license that can be found in the LICENSE.txt file.
  */
@@ -446,6 +446,15 @@ public interface ReconfigurationProblem {
      * @return a set of VMs identifier
      */
     Set<VM> getManageableVMs();
+
+    /**
+     * Get the VMs that are supposed to be misplaced.
+     * This is the conjunction of all the VMs reported by views and constraints
+     * implementing {@link MisplacedVMsEstimator}.
+     *
+     * @return a set, possibly empty.
+     */
+    Set<VM> getMisplacedVMs();
 
     /**
      * Get the logger.

--- a/choco/src/main/java/org/btrplace/scheduler/choco/runner/single/InstanceSolverRunner.java
+++ b/choco/src/main/java/org/btrplace/scheduler/choco/runner/single/InstanceSolverRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright  2022 The BtrPlace Authors. All rights reserved.
+ * Copyright  2024 The BtrPlace Authors. All rights reserved.
  * Use of this source code is governed by a LGPL-style
  * license that can be found in the LICENSE.txt file.
  */
@@ -220,11 +220,12 @@ public class InstanceSolverRunner implements Callable<SolvingStatistics> {
                 .setNextVMsStates(toForge, toRun, toSleep, toKill)
                 .setParams(params);
 
+        final Set<VM> misplaced = new HashSet<>();
+        cConstraints.forEach(c -> misplaced.addAll(c.getMisPlacedVMs(instance)));
+        views.forEach(v -> misplaced.addAll(v.getMisPlacedVMs(instance)));
+        rpb.setMisplacedVMs(misplaced);
         if (params.doRepair()) {
-            Set<VM> toManage = new HashSet<>();
-            cConstraints.forEach(c -> toManage.addAll(c.getMisPlacedVMs(instance)));
-            views.forEach(v -> toManage.addAll(v.getMisPlacedVMs(instance)));
-            rpb.setManageableVMs(toManage);
+            rpb.setManageableVMs(misplaced);
         }
 
         //The core views have been instantiated and available through rp.getViews()

--- a/choco/src/test/java/org/btrplace/scheduler/choco/DefaultReconfigurationProblemTest.java
+++ b/choco/src/test/java/org/btrplace/scheduler/choco/DefaultReconfigurationProblemTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright  2023 The BtrPlace Authors. All rights reserved.
+ * Copyright  2024 The BtrPlace Authors. All rights reserved.
  * Use of this source code is governed by a LGPL-style
  * license that can be found in the LICENSE.txt file.
  */
@@ -23,6 +23,7 @@ import org.chocosolver.solver.exception.ContradictionException;
 import org.chocosolver.solver.variables.IntVar;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+import org.testng.collections.Sets;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -639,12 +640,14 @@ public class DefaultReconfigurationProblemTest {
                 Collections.singleton(vm5),
                 Collections.singleton(vm1),
                 Collections.emptySet(),
-                map.getAllVMs());
+                map.getAllVMs(),
+                Sets.newHashSet(vm1));
         Assert.assertTrue(rp.getFutureSleepingVMs().contains(vm1));
         Assert.assertTrue(rp.getFutureReadyVMs().contains(vm2));
         Assert.assertTrue(rp.getFutureSleepingVMs().contains(vm3));
         Assert.assertTrue(rp.getFutureReadyVMs().contains(vm4));
         Assert.assertTrue(rp.getFutureRunningVMs().contains(vm5));
+        Assert.assertEquals(Sets.newHashSet(vm1), rp.getMisplacedVMs());
     }
 
     /**


### PR DESCRIPTION
This set of VMs is computed from the views and the constraints. In repair mode, it is used to restrict the problem by fixing some VMs but in the rebuild mode, this set was ignored and not available.

In practice, it is however something useful to have inside the search heuristics to help focusing on critical VMs.

Close #491.